### PR TITLE
2 Small fixes to use the correct archive description function and echoing the post_except in the alt tag.

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -2,7 +2,7 @@
 <main id="content" role="main">
 <header class="header">
 <h1 class="entry-title" itemprop="name"><?php the_archive_title(); ?></h1>
-<div class="archive-meta" itemprop="description"><?php if ( '' != the_archive_description() ) { echo esc_html( the_archive_description() ); } ?></div>
+<div class="archive-meta" itemprop="description"><?php if ( '' != get_the_archive_description() ) { echo esc_html( get_the_archive_description() ); } ?></div>
 </header>
 <?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 <?php get_template_part( 'entry' ); ?>

--- a/attachment.php
+++ b/attachment.php
@@ -15,7 +15,7 @@
 <div class="entry-content" itemprop="mainContentOfPage">
 <div class="entry-attachment">
 <?php if ( wp_attachment_is_image( $post->ID ) ) : $att_image = wp_get_attachment_image_src( $post->ID, 'full' ); ?>
-<p class="attachment"><a href="<?php echo esc_url( wp_get_attachment_url( $post->ID ) ); ?>" title="<?php the_title_attribute(); ?>" rel="attachment"><img src="<?php echo esc_url( $att_image[0] ); ?>" width="<?php echo esc_attr( $att_image[1] ); ?>" height="<?php echo esc_attr( $att_image[2] ); ?>" class="attachment-full" alt="<?php $post->post_excerpt; ?>" itemprop="image" /></a></p>
+<p class="attachment"><a href="<?php echo esc_url( wp_get_attachment_url( $post->ID ) ); ?>" title="<?php the_title_attribute(); ?>" rel="attachment"><img src="<?php echo esc_url( $att_image[0] ); ?>" width="<?php echo esc_attr( $att_image[1] ); ?>" height="<?php echo esc_attr( $att_image[2] ); ?>" class="attachment-full" alt="<?php echo $post->post_excerpt; ?>" itemprop="image" /></a></p>
 <?php else : ?>
 <a href="<?php echo esc_url( wp_get_attachment_url( $post->ID ) ); ?>" title="<?php echo esc_attr( get_the_title( $post->ID ), 1 ); ?>" rel="attachment"><?php echo esc_url( basename( $post->guid ) ); ?></a>
 <?php endif; ?>

--- a/category.php
+++ b/category.php
@@ -2,7 +2,7 @@
 <main id="content" role="main">
 <header class="header">
 <h1 class="entry-title" itemprop="name"><?php single_term_title(); ?></h1>
-<div class="archive-meta" itemprop="description"><?php if ( '' != the_archive_description() ) { echo esc_html( the_archive_description() ); } ?></div>
+<div class="archive-meta" itemprop="description"><?php if ( '' != get_the_archive_description() ) { echo esc_html( get_the_archive_description() ); } ?></div>
 </header>
 <?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 <?php get_template_part( 'entry' ); ?>

--- a/tag.php
+++ b/tag.php
@@ -2,7 +2,7 @@
 <main id="content" role="main">
 <header class="header">
 <h1 class="entry-title" itemprop="name"><?php single_term_title(); ?></h1>
-<div class="archive-meta" itemprop="description"><?php if ( '' != the_archive_description() ) { echo esc_html( the_archive_description() ); } ?></div>
+<div class="archive-meta" itemprop="description"><?php if ( '' != get_the_archive_description() ) { echo esc_html( get_the_archive_description() ); } ?></div>
 </header>
 <?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 <?php get_template_part( 'entry' ); ?>


### PR DESCRIPTION
Hey! I got 2 small commits for you to consider merging into your theme.

1. `the_archive_description()` doesn't actually return any HTML but echoes it right away. This can be fixed this by replacing it with `get_the_archive_description()`

2. The `post_excerpt` is never echoed in the attachment alt tag, This can be fixed by adding `echo` in front of the statement.