### PR TITLE
Make entry-summary time datetime format W3C-valid

### DIFF
--- a/entry-meta.php
+++ b/entry-meta.php
@@ -1,6 +1,6 @@
 <div class="entry-meta">
 <span class="author vcard"<?php if ( is_single() ) { echo ' itemprop="author" itemscope itemtype="https://schema.org/Person"><span itemprop="name">'; } else { echo '><span>'; } ?><?php the_author_posts_link(); ?></span></span>
 <span class="meta-sep"> | </span>
-<time class="entry-date" datetime="<?php echo esc_attr( get_the_date() ); ?>" title="<?php echo esc_attr( get_the_date() ); ?>" <?php if ( is_single() ) { echo 'itemprop="datePublished" pubdate'; } ?>><?php the_time( get_option( 'date_format' ) ); ?></time>
+<time class="entry-date" datetime="<?php echo esc_attr( get_the_date('Y-m-d') ); ?>" title="<?php echo esc_attr( get_the_date() ); ?>" <?php if ( is_single() ) { echo 'itemprop="datePublished" pubdate'; } ?>><?php the_time( get_option( 'date_format' ) ); ?></time>
 <?php if ( is_single() ) { echo '<meta itemprop="dateModified" content="' . esc_attr( get_the_modified_date() ) . '" />'; } ?>
 </div>

--- a/entry-summary.php
+++ b/entry-summary.php
@@ -2,7 +2,7 @@
 <?php if ( ( has_post_thumbnail() ) && ( !is_search() ) ) : ?>
 <a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>"><?php the_post_thumbnail(); ?></a>
 <?php endif; ?>
-<span itemprop="description"><?php echo(get_the_excerpt()); ?></span>
+<span itemprop="description"><?php the_excerpt(); ?></span>
 <?php if ( is_search() ) { ?>
 <div class="entry-links"><?php wp_link_pages(); ?></div>
 <?php } ?>

--- a/entry-summary.php
+++ b/entry-summary.php
@@ -2,7 +2,7 @@
 <?php if ( ( has_post_thumbnail() ) && ( !is_search() ) ) : ?>
 <a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>"><?php the_post_thumbnail(); ?></a>
 <?php endif; ?>
-<span itemprop="description"><?php the_excerpt(); ?></span>
+<span itemprop="description"><?php echo(get_the_excerpt()); ?></span>
 <?php if ( is_search() ) { ?>
 <div class="entry-links"><?php wp_link_pages(); ?></div>
 <?php } ?>

--- a/entry-summary.php
+++ b/entry-summary.php
@@ -1,9 +1,9 @@
 <div class="entry-summary">
-    <?php if ( ( has_post_thumbnail() ) && ( !is_search() ) ) : ?>
-    <a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>"><?php the_post_thumbnail(); ?></a>
-    <?php endif; ?>
-    <span itemprop="description"><?php echo(get_the_excerpt()); ?></span>
-    <?php if ( is_search() ) { ?>
-    <div class="entry-links"><?php wp_link_pages(); ?></div>
-    <?php } ?>
+<?php if ( ( has_post_thumbnail() ) && ( !is_search() ) ) : ?>
+<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>"><?php the_post_thumbnail(); ?></a>
+<?php endif; ?>
+<span itemprop="description"><?php the_excerpt(); ?></span>
+<?php if ( is_search() ) { ?>
+<div class="entry-links"><?php wp_link_pages(); ?></div>
+<?php } ?>
 </div>

--- a/entry-summary.php
+++ b/entry-summary.php
@@ -1,9 +1,9 @@
 <div class="entry-summary">
-<?php if ( ( has_post_thumbnail() ) && ( !is_search() ) ) : ?>
-<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>"><?php the_post_thumbnail(); ?></a>
-<?php endif; ?>
-<span itemprop="description"><?php the_excerpt(); ?></span>
-<?php if ( is_search() ) { ?>
-<div class="entry-links"><?php wp_link_pages(); ?></div>
-<?php } ?>
+    <?php if ( ( has_post_thumbnail() ) && ( !is_search() ) ) : ?>
+    <a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>"><?php the_post_thumbnail(); ?></a>
+    <?php endif; ?>
+    <span itemprop="description"><?php echo(get_the_excerpt()); ?></span>
+    <?php if ( is_search() ) { ?>
+    <div class="entry-links"><?php wp_link_pages(); ?></div>
+    <?php } ?>
 </div>


### PR DESCRIPTION
Re: #32 --

If I understand correctly, `get_the_date()` leverages the date format set on options-general.php. But this is likely intended to output a human-readable date.

Where used as the `datetime` property in the `time` element, I think this should be enforced as a W3C-compliant machine date format.

Human-readable format should be left in tact as the element content.

_I'm pretty new at this. This is my first attempt at committing a change to a forked repo, and first pull request. Please forgive/feed back on any faux pas._